### PR TITLE
Fix module export for babel 6. Refs #9.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@ root: true
 env:
     es6: true
     mocha: true
+    node: true
 
 extends:
     "eslint:recommended"

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import getRulesMatcher from './rulesMatcher';
 import getReset from './resetRules';
 import createResetRule from './createResetRule';
 
-export default postcss.plugin('postcss-autoreset', (opts = {})=> {
+module.exports = postcss.plugin('postcss-autoreset', (opts = {})=> {
   opts.rulesMatcher = opts.rulesMatcher || 'bem';
   opts.reset = opts.reset || 'initial';
   const rulesMatcher = getRulesMatcher(opts.rulesMatcher);


### PR DESCRIPTION
Change the way the module is exported, so that it can be `required` without using `require('postcss-autoreset').default` (due to babel 6 way of dealing with es6 default).