### PR TITLE
Improve accuracy of SUIT CSS regex

### DIFF
--- a/src/rulesMatcher.es6
+++ b/src/rulesMatcher.es6
@@ -1,10 +1,15 @@
+/**
+ * Demo - https://regex101.com/r/AA4xaq/3
+ */
+const suitRegex = /^\.(?:[a-z0-9]*-)?[A-Z](?:[a-zA-Z0-9]+)(?:-[a-zA-Z0-9]+)?$/;
+
 const matchers = {
   bem({selector}) {
     return !selector.match(/(--|:)/);
   },
 
   suit({selector}) {
-    return !(selector.match(/(--|:)/) || selector.match(/\.is\-/i));
+    return selector.charAt(0) === '.' && suitRegex.test(selector);
   }
 };
 

--- a/test/fixtures/filter-suit.css
+++ b/test/fixtures/filter-suit.css
@@ -6,6 +6,18 @@
   background-color: red;
 }
 
+.namespace-MyComponent {
+  cat: dog;
+}
+
+.namespace-MyComponent-desc {
+  cat: dog;
+}
+
+.MyComponent[aria-hidden="true"] {
+  display: none;
+}
+
 .MyComponent.is-animating {
   cat: dog;
 }

--- a/test/fixtures/filter-suit.expected.css
+++ b/test/fixtures/filter-suit.expected.css
@@ -1,4 +1,6 @@
 .MyComponent,
+.namespace-MyComponent,
+.namespace-MyComponent-desc,
 .MyComponent-part,
 .MyComponent-anotherPart {
   all: initial;
@@ -10,6 +12,18 @@
 
 .MyComponent:hover {
   background-color: red;
+}
+
+.namespace-MyComponent {
+  cat: dog;
+}
+
+.namespace-MyComponent-desc {
+  cat: dog;
+}
+
+.MyComponent[aria-hidden="true"] {
+  display: none;
 }
 
 .MyComponent.is-animating {


### PR DESCRIPTION
This adds some extra test cases for SUIT selectors and makes the regex
more robust against edge cases.

```
^\.                  - Match a dot at the start of the string
(?:[a-z0-9]*-)?      - Then look for optional namespace
[A-Z]                - Match a single capital letter at the start of Component name
(?:[a-zA-Z0-9]+)     - Match the rest of the component name...
(?:-[a-zA-Z0-9]+)?$  - Match optional descendant
```

https://regex101.com/r/AA4xaq/3

Fixes #16

cc @giuseppeg