### PR TITLE
Prevent duplicate selectors being added to reset ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - do not modify css if not required
+- Fix duplicate selector issue when using nested rulesets. ([#18](https://github.com/maximkoretskiy/postcss-autoreset/pull/18))
 
 ## [1.2.0] - 2016-09-29
 - Improved accuracy of SUIT CSS regex (see https://github.com/maximkoretskiy/postcss-autoreset/pull/17 and https://github.com/maximkoretskiy/postcss-autoreset/issues/16). Thnx @giuseppeg and @simonsmith for suggestion and contribution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- do not modify css if not required
 
 ## [1.2.0] - 2016-09-29
 - Improved accuracy of SUIT CSS regex (see https://github.com/maximkoretskiy/postcss-autoreset/pull/17 and https://github.com/maximkoretskiy/postcss-autoreset/issues/16). Thnx @giuseppeg and @simonsmith for suggestion and contribution.

--- a/src/index.es6
+++ b/src/index.es6
@@ -3,6 +3,8 @@ import getRulesMatcher from './rulesMatcher';
 import getReset from './resetRules';
 import createResetRule from './createResetRule';
 
+const contains = (array, item) => array.indexOf(item) !== -1;
+
 export default postcss.plugin('postcss-autoreset', (opts = {})=> {
   opts.rulesMatcher = opts.rulesMatcher || 'bem';
   opts.reset = opts.reset || 'initial';
@@ -11,8 +13,9 @@ export default postcss.plugin('postcss-autoreset', (opts = {})=> {
   return (css) => {
     const matchedSelectors = [];
     css.walkRules((rule)=> {
-      if (rulesMatcher(rule)) {
-        matchedSelectors.push(rule.selector);
+      const {selector} = rule;
+      if (!contains(matchedSelectors, selector) && rulesMatcher(rule)) {
+        matchedSelectors.push(selector);
       }
     });
     if (!matchedSelectors.length) return;

--- a/src/index.es6
+++ b/src/index.es6
@@ -15,6 +15,7 @@ export default postcss.plugin('postcss-autoreset', (opts = {})=> {
         matchedSelectors.push(rule.selector);
       }
     });
+    if (!matchedSelectors.length) return;
     css.prepend(
       createResetRule(matchedSelectors, reset)
     );

--- a/test/fixtures/filter-suit.css
+++ b/test/fixtures/filter-suit.css
@@ -30,6 +30,18 @@
   margin: 10px;
 }
 
+@media (min-width: 800px) {
+  .MyComponent-part {
+    margin: 10px;
+  }
+}
+
+.MyComponent {
+  & .MyComponent-part {
+    margin: 10px;
+  }
+}
+
 .MyComponent-anotherPart {
   background-color: #FFF;
 }

--- a/test/fixtures/filter-suit.expected.css
+++ b/test/fixtures/filter-suit.expected.css
@@ -38,6 +38,18 @@
   margin: 10px;
 }
 
+@media (min-width: 800px) {
+  .MyComponent-part {
+    margin: 10px;
+  }
+}
+
+.MyComponent {
+  & .MyComponent-part {
+    margin: 10px;
+  }
+}
+
 .MyComponent-anotherPart {
   background-color: #FFF;
 }

--- a/test/index.es6
+++ b/test/index.es6
@@ -2,6 +2,13 @@ import assert from 'assert';
 import {read, process} from './helpers';
 
 describe('postcss-autoreset', ()=>{
+  it('does not modify if there if nothing to require', ()=> {
+    assert.equal(
+      process('empty').css,
+      read('empty')
+    );
+  });
+
   it('works fine with bem rules matcher(default)', ()=> {
     assert.equal(
       process('filter-bem').css,


### PR DESCRIPTION
If a selector appeared more than once (media query, nesting) it was being duplicated in the reset ruleset. This change adds a check for the selector first. 

cc @giuseppeg