### PR TITLE
Changed keyframe test to also ignore keyframes with vendor prefixes

### DIFF
--- a/src/index.es6
+++ b/src/index.es6
@@ -14,7 +14,7 @@ export default postcss.plugin('postcss-autoreset', (opts = {})=> {
     const matchedSelectors = [];
     css.walkRules((rule)=> {
       const {selector} = rule;
-      if (rule.parent.name === 'keyframes') return;
+      if (/^(-(webkit|moz|ms|o)-)?keyframes$/.test(rule.parent.name)) return;
       if (!contains(matchedSelectors, selector) && rulesMatcher(rule)) {
         matchedSelectors.push(selector);
       }

--- a/test/fixtures/keyframes.css
+++ b/test/fixtures/keyframes.css
@@ -9,3 +9,14 @@
     transform: none;
   }
 }
+@-webkit-keyframes fadeInUp {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 100%, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/test/fixtures/keyframes.expected.css
+++ b/test/fixtures/keyframes.expected.css
@@ -9,3 +9,14 @@
     transform: none;
   }
 }
+@-webkit-keyframes fadeInUp {
+  0% {
+    opacity: 0;
+    transform: translate3d(0, 100%, 0);
+  }
+
+  100% {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
When the CSS contains keyframes with vendor prefixes, they will not match the selector test.